### PR TITLE
Ensure an artifact always exists, otherwise merging will be blocked

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -64,10 +64,15 @@ jobs:
         continue-on-error: ${{ matrix.continue_on_error }}
         run: |
           # Capture coverage reports for processing with Sonar.
-          export PMC_ARTIFACTS=true
+          export PMC_ARTIFACTS=${{ matrix.check_code_coverage }}
 
           . pmc-manifest
           . pmc-test-phpunit
+
+          # Ensure an artifact is uploaded, or `download-artifacts` will fail.
+          if [[ ${{ matrix.check_code_coverage }} ]]; then
+            touch ${{ github.workspace }}/artifacts/pmc
+          fi
 
       - name: Ensure version-controlled files are not modified during the tests
         run: git diff --exit-code
@@ -79,7 +84,7 @@ jobs:
         with:
           name: phpunit-coverage
           path: ${{ github.workspace }}/artifacts/*.xml
-          if-no-files-found: warn
+          if-no-files-found: error
 
   jest:
     name: JS
@@ -115,16 +120,13 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
 
-      # This step fails if there are no artifacts, so subsequent steps require `if` checks to proceed.
       - name: Download artifacts
-        id: download-artifacts
         uses: actions/download-artifact@v3
         with:
           name: phpunit-coverage
           path: ${{ github.workspace }}/artifacts
 
       - name: Fix paths in coverage reports
-        if: ${{ steps.download-artifacts.conclusion == 'success' }}
         run: |
           # https://docs.sonarcloud.io/enriching/test-coverage/php-test-coverage/
           for REPORT in ./artifacts/coverage-*.xml; do
@@ -132,8 +134,6 @@ jobs:
           done
 
       - name: Set Sonar variables
-        id: set-sonar-vars
-        if: ${{ always() }}
         run: |
           if [[ -d ./artifacts ]]; then
             ls -l ./artifacts
@@ -146,7 +146,6 @@ jobs:
           fi
 
       - name: Analyze with SonarCloud
-        if: ${{ always() }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           # Token needed to get PR information, if any.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -72,7 +72,7 @@ jobs:
           # Ensure an artifact is uploaded, or `download-artifacts` will fail.
           if [[ "true" == "${{ matrix.check_code_coverage }}" && ! -d ${{ github.workspace }}/artifacts ]]; then
             mkdir ${{ github.workspace }}/artifacts
-            touch ${{ github.workspace }}/artifacts/pmc.xml
+            touch ${{ github.workspace }}/artifacts/pmc
           fi
 
       - name: Ensure version-controlled files are not modified during the tests
@@ -84,7 +84,9 @@ jobs:
         if: ${{ matrix.check_code_coverage }}
         with:
           name: phpunit-coverage
-          path: ${{ github.workspace }}/artifacts/*.xml
+          path: |
+            ${{ github.workspace }}/artifacts/pmc
+            ${{ github.workspace }}/artifacts/*.xml
           if-no-files-found: error
 
   jest:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -131,6 +131,10 @@ jobs:
 
       - name: Fix paths in coverage reports
         run: |
+          if [[ -z "$(find ./artifacts -type f -name 'coverage-*.xml')" ]]; then
+            exit 0
+          fi
+
           # https://docs.sonarcloud.io/enriching/test-coverage/php-test-coverage/
           for REPORT in ./artifacts/coverage-*.xml; do
             sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' "$REPORT"
@@ -141,7 +145,7 @@ jobs:
           if [[ -d ./artifacts ]]; then
             ls -l ./artifacts
 
-            echo "sonar.php.coverage.reportPaths=$(find ./artifacts -type f -name '*.xml' | tr '\n', ',' | sed 's/,$//g')" >> "./sonar-project.properties"
+            echo "sonar.php.coverage.reportPaths=$(find ./artifacts -type f -name 'coverage-*.xml' | tr '\n', ',' | sed 's/,$//g')" >> "./sonar-project.properties"
 
             cat ./sonar-project.properties
           else

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Set Sonar variables
         id: set-sonar-vars
-        if: ${{ success() || failure() }}
+        if: ${{ always() }}
         run: |
           if [[ -d ./artifacts ]]; then
             ls -l ./artifacts
@@ -146,7 +146,7 @@ jobs:
           fi
 
       - name: Analyze with SonarCloud
-        if: ${{ steps.set-sonar-vars.conclusion == 'success' }}
+        if: ${{ always() }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           # Token needed to get PR information, if any.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -115,6 +115,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
 
+      # This step fails if there are no artifacts, so subsequent steps require `if` checks to proceed.
       - name: Download artifacts
         id: download-artifacts
         uses: actions/download-artifact@v3
@@ -131,6 +132,7 @@ jobs:
           done
 
       - name: Set Sonar variables
+        id: set-sonar-vars
         if: ${{ success() || failure() }}
         run: |
           if [[ -d ./artifacts ]]; then
@@ -144,6 +146,7 @@ jobs:
           fi
 
       - name: Analyze with SonarCloud
+        if: ${{ steps.set-sonar-vars.conclusion == 'success' }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           # Token needed to get PR information, if any.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,7 +70,8 @@ jobs:
           . pmc-test-phpunit
 
           # Ensure an artifact is uploaded, or `download-artifacts` will fail.
-          if [[ ${{ matrix.check_code_coverage }} ]]; then
+          if [[ ${{ matrix.check_code_coverage }} && ! -d ${{ github.workspace }}/artifacts ]]; then
+            mkdir ${{ github.workspace }}/artifacts
             touch ${{ github.workspace }}/artifacts/pmc
           fi
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -116,12 +116,14 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
 
       - name: Download artifacts
+        id: download-artifacts
         uses: actions/download-artifact@v3
         with:
           name: phpunit-coverage
           path: ${{ github.workspace }}/artifacts
 
       - name: Fix paths in coverage reports
+        if: ${{ steps.download-artifacts.conclusion == 'success' }}
         run: |
           # https://docs.sonarcloud.io/enriching/test-coverage/php-test-coverage/
           for REPORT in ./artifacts/coverage-*.xml; do
@@ -129,6 +131,7 @@ jobs:
           done
 
       - name: Set Sonar variables
+        if: ${{ success() || failure() }}
         run: |
           if [[ -d ./artifacts ]]; then
             ls -l ./artifacts
@@ -137,8 +140,7 @@ jobs:
 
             cat ./sonar-project.properties
           else
-            ls -l .
-            exit 1
+            echo "sonar.php.coverage.reportPaths=" >> "./sonar-project.properties"
           fi
 
       - name: Analyze with SonarCloud

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -132,11 +132,13 @@ jobs:
       - name: Fix paths in coverage reports
         run: |
           if [[ -z "$(find ./artifacts -type f -name 'coverage-*.xml')" ]]; then
+            echo "No reports to update"
             exit 0
           fi
 
           # https://docs.sonarcloud.io/enriching/test-coverage/php-test-coverage/
           for REPORT in ./artifacts/coverage-*.xml; do
+            echo "Updating paths in ${REPORT}"
             sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' "$REPORT"
           done
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,7 +70,7 @@ jobs:
           . pmc-test-phpunit
 
           # Ensure an artifact is uploaded, or `download-artifacts` will fail.
-          if [[ ${{ matrix.check_code_coverage }} && ! -d ${{ github.workspace }}/artifacts ]]; then
+          if [[ "true" == "${{ matrix.check_code_coverage }}" && ! -d ${{ github.workspace }}/artifacts ]]; then
             mkdir ${{ github.workspace }}/artifacts
             touch ${{ github.workspace }}/artifacts/pmc
           fi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -72,7 +72,7 @@ jobs:
           # Ensure an artifact is uploaded, or `download-artifacts` will fail.
           if [[ "true" == "${{ matrix.check_code_coverage }}" && ! -d ${{ github.workspace }}/artifacts ]]; then
             mkdir ${{ github.workspace }}/artifacts
-            touch ${{ github.workspace }}/artifacts/pmc
+            touch ${{ github.workspace }}/artifacts/pmc.xml
           fi
 
       - name: Ensure version-controlled files are not modified during the tests

--- a/templates/bitbucket-sync-other-branches.yml
+++ b/templates/bitbucket-sync-other-branches.yml
@@ -2,7 +2,7 @@ name: Sync
 
 on:
   push:
-    exclude_branches:
+    branches-ignore:
       - main
       - master
 


### PR DESCRIPTION
If a PR doesn't touch any files that cause the unit-test steps to create artifacts, the `download-artifacts` action fails. It does not provide an option to ignore the failure (the `upload-artifacts` action does, however).