### PR TITLE
Add github actions

### DIFF
--- a/.github/workflows/jenkins.yml
+++ b/.github/workflows/jenkins.yml
@@ -1,0 +1,36 @@
+name: Jenkins
+
+on:
+  workflow_call:
+  inputs:
+    jenkins_url:
+      default: ''
+      description: 'Destination Jenkins URL.'
+      required: true
+      type: string
+    job_name:
+      default: ''
+      description: 'Jenkins Job Name.'
+      required: true
+      type: string
+    parameters:
+      default: ''
+      description: 'Query string attaching to Jenkins URL.'
+      required: false
+      type: string
+
+    secrets:
+      JENKINS_BUILD_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  jenkins:
+    name: Jenkins
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Job By Token
+        run: |
+          curl -s -o /dev/null -D -  "${{ inputs.jenkins_url }}?job=${{ inputs.job_name }}&token=${{ secrets.JENKINS_BUILD_TOKEN }}&${{ inputs.parameters }}"

--- a/.github/workflows/jenkins.yml
+++ b/.github/workflows/jenkins.yml
@@ -15,7 +15,7 @@ on:
         type: string
       PARAMETERS:
         default: ''
-        description: 'Query string attaching to Jenkins URL.'
+        description: 'Passing parameters to Jenkins Job with query string.'
         required: false
         type: string
     secrets:

--- a/.github/workflows/jenkins.yml
+++ b/.github/workflows/jenkins.yml
@@ -33,4 +33,4 @@ jobs:
     steps:
       - name: Trigger Job By Token
         run: |
-          curl -s -o /dev/null -D -  "${{ inputs.jenkins_url }}?job=${{ inputs.job_name }}&token=${{ secrets.JENKINS_BUILD_TOKEN }}&${{ inputs.parameters }}"
+          echo "${{ inputs.jenkins_url }}?job=${{ inputs.job_name }}&token=${{ secrets.JENKINS_BUILD_TOKEN }}&${{ inputs.parameters }}"

--- a/.github/workflows/jenkins.yml
+++ b/.github/workflows/jenkins.yml
@@ -3,17 +3,17 @@ name: Jenkins
 on:
   workflow_call:
     inputs:
-      jenkins_url:
+      JENKINS_URL:
         default: ''
         description: 'Destination Jenkins URL.'
         required: true
         type: string
-      job_name:
+      JOB_NAME:
         default: ''
         description: 'Jenkins Job Name.'
         required: true
         type: string
-      parameters:
+      PARAMETERS:
         default: ''
         description: 'Query string attaching to Jenkins URL.'
         required: false
@@ -32,4 +32,4 @@ jobs:
     steps:
       - name: Trigger Job By Token
         run: |
-          echo "${{ inputs.jenkins_url }}?job=${{ inputs.job_name }}&token=${{ secrets.JENKINS_BUILD_TOKEN }}&${{ inputs.parameters }}"
+          curl -s -o /dev/null -D -  "${{ inputs.JENKINS_URL }}?job=${{ inputs.JOB_NAME }}&token=${{ secrets.JENKINS_BUILD_TOKEN }}&${{ inputs.PARAMETERS }}"

--- a/.github/workflows/jenkins.yml
+++ b/.github/workflows/jenkins.yml
@@ -2,23 +2,22 @@ name: Jenkins
 
 on:
   workflow_call:
-  inputs:
-    jenkins_url:
-      default: ''
-      description: 'Destination Jenkins URL.'
-      required: true
-      type: string
-    job_name:
-      default: ''
-      description: 'Jenkins Job Name.'
-      required: true
-      type: string
-    parameters:
-      default: ''
-      description: 'Query string attaching to Jenkins URL.'
-      required: false
-      type: string
-
+    inputs:
+      jenkins_url:
+        default: ''
+        description: 'Destination Jenkins URL.'
+        required: true
+        type: string
+      job_name:
+        default: ''
+        description: 'Jenkins Job Name.'
+        required: true
+        type: string
+      parameters:
+        default: ''
+        description: 'Query string attaching to Jenkins URL.'
+        required: false
+        type: string
     secrets:
       JENKINS_BUILD_TOKEN:
         required: true

--- a/.github/workflows/merge-main-to-qa.yml
+++ b/.github/workflows/merge-main-to-qa.yml
@@ -1,14 +1,20 @@
-name: Sync qa branch
+name: Merge main to qa
 
 on:
   workflow_call:
+    inputs:
+      WORKFLOW_DISPATCH_NAME:
+        default: 'Jenkins'
+        description: 'Workflow to trigger after sync.'
+        required: false
+        type: string
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  sync-qa:
-    name: Sync
+  merge-main-to-qa:
+    name: Merge
     runs-on: ubuntu-latest
 
     steps:
@@ -43,5 +49,7 @@ jobs:
           # push code back to qa
           git push origin feature/qa-sync-test
 
-          gh workflow run "qa sync" -r "feature/qa-sync-test"
+          # Deploy qa branch to pmcqa
+          gh workflow run "${{ inputs.WORKFLOW_DISPATCH_NAME }}" -r "feature/qa-sync-test"
+
 

--- a/.github/workflows/merge-main-to-qa.yml
+++ b/.github/workflows/merge-main-to-qa.yml
@@ -27,29 +27,29 @@ jobs:
           git fetch
 
           # make sure qa is latest
-          git checkout feature/qa-sync-test
+          git checkout qa
           git pull
 
           # make sure main is latest
-          git checkout feature/PMCS-5327-jenkins
+          git checkout main
           git pull
 
           # create a temporary sync-master2qa branch to resolve conflict
           git checkout -b sync-main2qa
           # merge qa into sync-main2qa auto resolve by taking master branch code
-          git merge -s ours --no-edit --allow-unrelated-histories feature/qa-sync-test
+          git merge -s ours --no-edit --allow-unrelated-histories qa
 
           # merge temp branch sync-main2qa into qa
-          git checkout feature/qa-sync-test
+          git checkout qa
           git merge --no-edit --allow-unrelated-histories sync-main2qa
 
           # remove the temp branch we just created
           git branch -D sync-main2qa
 
           # push code back to qa
-          git push origin feature/qa-sync-test
+          git push origin qa
 
           # Deploy qa branch to pmcqa
-          gh workflow run "${{ inputs.WORKFLOW_DISPATCH_NAME }}" -r "feature/qa-sync-test"
+          gh workflow run "${{ inputs.WORKFLOW_DISPATCH_NAME }}" -r "qa"
 
 

--- a/.github/workflows/merge-main-to-qa.yml
+++ b/.github/workflows/merge-main-to-qa.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       WORKFLOW_DISPATCH_NAME:
         default: 'Jenkins'
-        description: 'Workflow to trigger after sync.'
+        description: 'Workflow to trigger after merge.'
         required: false
         type: string
 
@@ -49,7 +49,7 @@ jobs:
           # push code back to qa
           git push origin qa
 
-          # Deploy qa branch to pmcqa
+          # trigger gh actions within the repo to deploy qa branch to pmcqa
           gh workflow run "${{ inputs.WORKFLOW_DISPATCH_NAME }}" -r "qa"
 
 

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -35,7 +35,7 @@ jobs:
 
           # merge temp branch sync-main2qa into qa
           git checkout feature/qa-sync-test
-          git merge --no-edit sync-main2qa
+          git merge --no-edit --allow-unrelated-histories sync-main2qa
 
           # remove the temp branch we just created
           git branch -D sync-main2qa

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set Git config
-      run: |
-          git config --local user.name "Github Actions"
-    - name: Merge main back to qa
-      run: |
-          git fetch --unshallow
-          git checkout feature/qa-sync-test
-          git pull
-          git merge --no-ff main -m "Auto-merge main back to qa"
-          git push
+      - uses: actions/checkout@v2
+      - name: Set Git config
+        run: |
+            git config --local user.name "Github Actions"
+      - name: Merge main back to qa
+        run: |
+            git fetch --unshallow
+            git checkout feature/qa-sync-test
+            git pull
+            git merge --no-ff main -m "Auto-merge main back to qa"
+            git push

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -1,5 +1,9 @@
 name: Sync qa branch
 
+on:
+  push:
+    - feature/PMCS-5327-jenkins
+
 permissions:
   contents: read
 
@@ -15,8 +19,26 @@ jobs:
             git config --local user.name "Github Actions"
       - name: Merge main back to qa
         run: |
-            git fetch --unshallow
-            git checkout feature/qa-sync-test
-            git pull
-            git merge --no-ff main -m "Auto-merge main back to qa"
-            git push
+          # make sure qa is latest
+          git checkout feature/qa-sync-test
+          git pull
+
+          # make sure main is latest
+          git checkout feature/PMCS-5327-jenkins
+          git pull
+
+          # create a temporary sync-master2qa branch to resolve conflict
+          git checkout -b sync-main2qa
+          # merge qa into sync-main2qa auto resolve by taking master branch code
+          git merge -s ours feature/qa-sync-test
+
+          # merge temp branch sync-main2qa into qa
+          git checkout feature/qa-sync-test
+          git merge sync-main2qa
+
+          # remove the temp branch we just created
+          git branch -D sync-main2qa
+
+          # push code back to qa
+          git push origin feature/qa-sync-test
+

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -3,9 +3,6 @@ name: Sync qa branch
 on:
   workflow_call:
 
-permissions:
-  contents: read|write
-
 jobs:
   sync-qa:
     name: Sync

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -40,3 +40,5 @@ jobs:
           # push code back to qa
           git push origin feature/qa-sync-test
 
+          gh workflow run jenkins.yml --ref feature/qa-sync-test
+

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -43,5 +43,5 @@ jobs:
           # push code back to qa
           git push origin feature/qa-sync-test
 
-          gh workflow run jenkins.yml --ref feature/qa-sync-test
+          gh workflow run "qa sync" -r "feature/qa-sync-test"
 

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 permissions:
-  contents: read
+  contents: read|write
 
 jobs:
   sync-qa:

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -3,6 +3,9 @@ name: Sync qa branch
 on:
   workflow_call:
 
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   sync-qa:
     name: Sync

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -31,7 +31,7 @@ jobs:
           # create a temporary sync-master2qa branch to resolve conflict
           git checkout -b sync-main2qa
           # merge qa into sync-main2qa auto resolve by taking master branch code
-          git merge -s ours --no-edit feature/qa-sync-test
+          git merge -s ours --no-edit --allow-unrelated-histories feature/qa-sync-test
 
           # merge temp branch sync-main2qa into qa
           git checkout feature/qa-sync-test

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -1,8 +1,7 @@
 name: Sync qa branch
 
 on:
-  push:
-    - feature/PMCS-5327-jenkins
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -1,0 +1,22 @@
+name: Sync qa branch
+
+permissions:
+  contents: read
+
+jobs:
+  sync-qa:
+    name: Sync
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set Git config
+      run: |
+          git config --local user.name "Github Actions"
+    - name: Merge main back to qa
+      run: |
+          git fetch --unshallow
+          git checkout feature/qa-sync-test
+          git pull
+          git merge --no-ff main -m "Auto-merge main back to qa"
+          git push

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -30,11 +30,11 @@ jobs:
           # create a temporary sync-master2qa branch to resolve conflict
           git checkout -b sync-main2qa
           # merge qa into sync-main2qa auto resolve by taking master branch code
-          git merge -s ours feature/qa-sync-test
+          git merge -s ours --no-edit feature/qa-sync-test
 
           # merge temp branch sync-main2qa into qa
           git checkout feature/qa-sync-test
-          git merge sync-main2qa
+          git merge --no-edit sync-main2qa
 
           # remove the temp branch we just created
           git branch -D sync-main2qa

--- a/.github/workflows/sync-qa.yml
+++ b/.github/workflows/sync-qa.yml
@@ -18,6 +18,8 @@ jobs:
             git config --local user.name "Github Actions"
       - name: Merge main back to qa
         run: |
+          git fetch
+
           # make sure qa is latest
           git checkout feature/qa-sync-test
           git pull

--- a/templates/jenkins.yml
+++ b/templates/jenkins.yml
@@ -1,0 +1,14 @@
+name: Jenkins
+
+on: [push]
+
+jobs:
+  jenkins:
+    name: Jenkins
+    uses: penske-media-corp/github-workflows-wordpress/.github/workflows/jenkins.yml@main
+    with:
+      JENKINS_URL: https://JENKINS_HOSTNAME/buildByToken/buildWithParameters
+      JOB_NAME: JOB_NAME
+      PARAMETERS: "branch=main&theme=THEME"
+    secrets:
+      JENKINS_BUILD_TOKEN: ${{ secrets.JENKINS_BUILD_TOKEN }}

--- a/templates/pmc.yml
+++ b/templates/pmc.yml
@@ -45,4 +45,4 @@ jobs:
 
   merge-main-to-qa:
     name: Merge main to qa
-    uses: penske-media-corp/github-workflows-wordpress/.github/workflows/sync-qa.yml@main
+    uses: penske-media-corp/github-workflows-wordpress/.github/workflows/merge-main-to-qa.yml@main

--- a/templates/pmc.yml
+++ b/templates/pmc.yml
@@ -42,3 +42,7 @@ jobs:
       BITBUCKET_READ_ONLY_SSH_KEY: ${{ secrets.BITBUCKET_READ_ONLY_SSH_KEY }}
       GITHUB_READ_ONLY_SSH_KEY: ${{ secrets.PMC_GITHUB_ACTION_SSH_KEY }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  merge-main-to-qa:
+    name: Merge main to qa
+    uses: penske-media-corp/github-workflows-wordpress/.github/workflows/sync-qa.yml@main


### PR DESCRIPTION
This PR adds the following gh actions
* jenkins.yml - Helper to trigger jenkins job without `github.php`. For WP theme repos, this will be used to trigger `vipgo-auto-sync-theme` and `pmc-qa-vip-go`
* merge-main-to-qa.yml - Replacement for [merge-master-to-qa](https://jenkins.sheknows.io/job/merge-master-to-qa/) as the current jenkins job only works for BB  