### PR TITLE
Cancel in-progress runs following new pushes

### DIFF
--- a/.github/workflows/build-larva.yml
+++ b/.github/workflows/build-larva.yml
@@ -55,6 +55,10 @@ jobs:
     timeout-minutes: 90
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
+    concurrency:
+      group: ${{ github.ref_name || github.run_id }}
+      cancel-in-progress: true
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build-larva.yml
+++ b/.github/workflows/build-larva.yml
@@ -56,7 +56,7 @@ jobs:
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
     concurrency:
-      group: ${{ github.ref_name || github.run_id }}
+      group: ${{ github.ref_name || github.run_id }}-larva-assets
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ jobs:
     timeout-minutes: 90
     if: false
 
+    concurrency:
+      group: ${{ github.ref_name || github.run_id }}
+      cancel-in-progress: true
+
     steps:
       - name: Build static assets
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     if: false
 
     concurrency:
-      group: ${{ github.ref_name || github.run_id }}
+      group: ${{ github.ref_name || github.run_id }}-build-assets
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -18,6 +18,10 @@ jobs:
     timeout-minutes: 90
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
+    concurrency:
+      group: ${{ github.ref_name || github.run_id }}
+      cancel-in-progress: true
+
     steps:
       - name: Prepare environment
         uses: penske-media-corp/github-action-wordpress-test-setup@main

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
     concurrency:
-      group: ${{ github.ref_name || github.run_id }}
+      group: ${{ github.ref_name || github.run_id }}-coding-standards-phpcs
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,6 +18,10 @@ jobs:
     timeout-minutes: 90
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
+    concurrency:
+      group: ${{ github.ref_name || github.run_id }}
+      cancel-in-progress: true
+
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
+
+    concurrency:
+      group: ${{ github.ref_name || github.run_id }}
+      cancel-in-progress: true
 
     steps:
       - name: Prepare environment

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
     concurrency:
-      group: ${{ github.ref_name || github.run_id }}
+      group: ${{ github.ref_name || github.run_id }}-linting-php
       cancel-in-progress: true
 
     strategy:
@@ -55,7 +55,7 @@ jobs:
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
     concurrency:
-      group: ${{ github.ref_name || github.run_id }}
+      group: ${{ github.ref_name || github.run_id }}-linting-js
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -33,6 +33,10 @@ jobs:
       NPM_QAT_SCRIPT: "qat"
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
+    concurrency:
+      group: ${{ github.ref_name || github.run_id }}
+      cancel-in-progress: true
+
     steps:
       - name: Prepare environment
         uses: penske-media-corp/github-action-wordpress-test-setup@main

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -34,7 +34,7 @@ jobs:
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
     concurrency:
-      group: ${{ github.ref_name || github.run_id }}
+      group: ${{ github.ref_name || github.run_id }}-qat-playwright
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/sync-bitbucket.yml
+++ b/.github/workflows/sync-bitbucket.yml
@@ -28,7 +28,7 @@ jobs:
     if: false
 
     concurrency:
-      group: ${{ github.ref_name || github.run_id }}
+      group: ${{ github.ref_name || github.run_id }}-bitbucket-sync-push
       cancel-in-progress: true
 
     steps:
@@ -71,7 +71,11 @@ jobs:
     name: Delete from Bitbucket
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    if: ${{ github.event_name == 'delete' && github.repository != 'penske-media-corp/github-workflows-wordpress' }}
+    if: false
+
+    concurrency:
+      group: ${{ github.ref_name || github.run_id }}-bitbucket-sync-delete
+      cancel-in-progress: true
 
     steps:
       - name: Add SSH key

--- a/.github/workflows/sync-bitbucket.yml
+++ b/.github/workflows/sync-bitbucket.yml
@@ -25,13 +25,17 @@ jobs:
     name: Push to Bitbucket
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    if: ${{ github.event_name == 'push' && github.repository != 'penske-media-corp/github-workflows-wordpress' }}
+    if: false
+
+    concurrency:
+      group: ${{ github.ref_name || github.run_id }}
+      cancel-in-progress: true
 
     steps:
       - name: Add SSH key
         run: |
           mkdir -p "${HOME}/.ssh"
-  
+
           if [[ ! -f "${HOME}/.ssh/known_hosts" ]]; then
             touch "${HOME}/.ssh/known_hosts"
           fi
@@ -73,7 +77,7 @@ jobs:
       - name: Add SSH key
         run: |
           mkdir -p "${HOME}/.ssh"
-          
+
           if [[ ! -f "${HOME}/.ssh/known_hosts" ]]; then
             touch "${HOME}/.ssh/known_hosts"
           fi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
     concurrency:
-      group: ${{ github.ref_name || github.run_id }}
+      group: ${{ github.ref_name || github.run_id }}-unit-test-phpunit-${{ matrix.job_label_php }}-${{ matrix.job_label_wordpress }}
       cancel-in-progress: true
 
     services:
@@ -116,7 +116,7 @@ jobs:
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
     concurrency:
-      group: ${{ github.ref_name || github.run_id }}
+      group: ${{ github.ref_name || github.run_id }}-unit-test-jest
       cancel-in-progress: true
 
     steps:
@@ -143,7 +143,7 @@ jobs:
     needs: [ phpunit, jest ]
 
     concurrency:
-      group: ${{ github.ref_name || github.run_id }}
+      group: ${{ github.ref_name || github.run_id }}-unit-test-code-quality
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,6 +31,10 @@ jobs:
     timeout-minutes: 90
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
+    concurrency:
+      group: ${{ github.ref_name || github.run_id }}
+      cancel-in-progress: true
+
     services:
       memcached:
         image: memcached:alpine
@@ -111,6 +115,10 @@ jobs:
     timeout-minutes: 90
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}
 
+    concurrency:
+      group: ${{ github.ref_name || github.run_id }}
+      cancel-in-progress: true
+
     steps:
       - name: Prepare environment
         uses: penske-media-corp/github-action-wordpress-test-setup@main
@@ -133,6 +141,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: [ phpunit, jest ]
+
+    concurrency:
+      group: ${{ github.ref_name || github.run_id }}
+      cancel-in-progress: true
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
Prevent two of the same job from running simultaneously for a given ref, reducing runner minute usage.