### PR TITLE
update wp pipeline version

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         include:
           - php: '8.0'
-            wordpress: '6.0.3'
+            wordpress: '6.2.2'
             check_code_coverage: true
             continue_on_error: false
             job_label_php: 'current'


### PR DESCRIPTION
PASE has completed work to update PHPunit tests to be compatible with WordPress 6.2