### PR TITLE
Disable Vercel comment for pushes to default branch

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -39,7 +39,7 @@ jobs:
         name: Build & Deploy
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          github-comment: true
+          github-comment: ${{ github.ref_name == 'main' && 'false' || 'true' }}
           scope: ${{ secrets.VERCEL_ORG_ID }}
           vercel-args: ${{ github.ref_name == 'main' && '--prod' || '' }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
Comments are unnecessary on default branch, and require more permissions than we grant to the token.