### PR TITLE
More main branch deploy checks

### DIFF
--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -116,6 +116,7 @@ jobs:
         run: npm ci
       - name: Run checks # Run Checkly checks and record test session
         id: run-checks
+        if: github.ref != 'refs/heads/main' # We don't want to run checks on main branch pushes
         run: |
           npx checkly test --config=$(find . -name checkly.config.ts) -e ENVIRONMENT_URL=https://${{ env.FEATURE_BRANCH_NAME }}.${{ inputs.QA_SITE_DOMAIN }} --reporter=github --record
           cat checkly-github-report.md > $GITHUB_STEP_SUMMARY
@@ -123,4 +124,4 @@ jobs:
         # Only run if the pull request is merging into the main branch
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         id: deploy-checks
-        run: npx checkly deploy --force
+        run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force


### PR DESCRIPTION
Finding more bugs only noticeable when code is pushed into main.

- Only Run the checks on branches.
- `checkly deploy` needs to know where the config is at.