### PR TITLE
PASE-1948 | Add non-blocking unit test for WordPress 6.5

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -73,6 +73,14 @@ jobs:
             job_label_php: 'current'
             job_label_wordpress: 'latest'
 
+            # Temporary WordPress 6.5 testing (PASE-1948)
+          - php: '8.2'
+            wordpress: '6.5'
+            check_code_coverage: false
+            continue_on_error: true # non-failing
+            job_label_php: 'current'
+            job_label_wordpress: '6.5'
+
     steps:
       - name: Prepare environment
         uses: penske-media-corp/github-action-wordpress-test-setup@main


### PR DESCRIPTION
## Summary
This PR, when applied,
* Adds a non-blocking unit test against WordPress 6.5

## Issue URL or additional context
https://penskemedia.atlassian.net/browse/PASE-1948