### PR TITLE
PASE-2103 | Swap blocking WordPress 6.4 with 6.5 in unit test config

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,19 +67,11 @@ jobs:
       matrix:
         include:
           - php: '8.2'
-            wordpress: '6.4'
+            wordpress: '6.5'
             check_code_coverage: true
             continue_on_error: false
             job_label_php: 'current'
             job_label_wordpress: 'latest'
-
-            # Temporary WordPress 6.5 testing (PASE-1948)
-          - php: '8.2'
-            wordpress: '6.5'
-            check_code_coverage: false
-            continue_on_error: true # non-failing
-            job_label_php: 'current'
-            job_label_wordpress: '6.5'
 
     steps:
       - name: Prepare environment


### PR DESCRIPTION
For [PASE-2103](https://penskemedia.atlassian.net/browse/PASE-2103)

Removes temporary non-blocking WordPress 6.5 PHPUnit test and sets the main, blocking one from 6.4 to 6.5.