### PR TITLE
Update QAT workflow to use PR comments

### DIFF
--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -119,8 +119,11 @@ jobs:
         if: github.ref != 'refs/heads/main' # We don't want to run checks on main branch pushes
         continue-on-error: true
         run: |
+          set +e # Disable exit on error
           npx checkly test --config=$(find . -name checkly.config.ts) -e ENVIRONMENT_URL=https://${{ env.FEATURE_BRANCH_NAME }}.${{ inputs.QA_SITE_DOMAIN }} --reporter=github --record
-          if [ $? -ne 0 ]; then
+          exit_code=$?
+          set -e # Enable exit on error
+          if [ $exit_code -ne 0 ]; then
             echo "::error::Checkly checks failed. Please check the checkly-github-report.md in the summary for more details."
           else
             echo "Checkly checks Passed! Please check the checkly-github-report.md in the summary for more details."

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -146,8 +146,8 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyFailed = ${{ steps.checkly-deploy.outputs.checkly_failed }};
-            const checklyStatus = checklyFailed ? `:x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced (checklyFailed: ${checklyFailed})` : `:white_check_mark: All Playwright tests passed. Checkly Report (checklyFailed: ${checklyFailed})`;
+            const checklyFailed = ${{ steps.run-checks.outputs.checkly_failed }};
+            const checklyStatus = checklyFailed ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced (checklyFailed: ${checklyFailed})' : ':white_check_mark: All Playwright tests passed. Checkly Report (checklyFailed: ${checklyFailed})';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -95,7 +95,7 @@ jobs:
     needs:
       - check-qat
     # Run QAT only if the check-qat job succeeded, the event is a pull request, and the action is opened or ready_for_review
-    if: needs.check-qat.outputs.status == 'true' && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'ready_for_review')
+    if: needs.check-qat.outputs.status == 'true' && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.pull_request.draft == true)
 
     concurrency:
       group: ${{ github.ref_name || github.run_id }}-checkly-qat
@@ -140,7 +140,7 @@ jobs:
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
       - name: Add Checkly report comment to PR
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'ready_for_review')
+        if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.pull_request.draft == true)
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -119,7 +119,6 @@ jobs:
       - name: Run checks # Run Checkly checks and record test session
         id: run-checks
         if: github.ref != 'refs/heads/main' # We don't want to run checks on main branch pushes
-        # continue-on-error: true
         run: |
           set +e # Disable exit on error
           npx checkly test --config=$(find . -name checkly.config.ts) -e ENVIRONMENT_URL=https://${{ env.FEATURE_BRANCH_NAME }}.${{ inputs.QA_SITE_DOMAIN }} --reporter=github --record
@@ -140,8 +139,7 @@ jobs:
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
       - name: Add Checkly report comment to PR
         uses: actions/github-script@v6
-        # if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -145,7 +145,7 @@ jobs:
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
             const checklyFailed = ${{ steps.run-checks.outputs.checkly_failed }};
-            const checklyStatus = checklyFailed ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced.' : ':white_check_mark: All Playwright tests passed. Checkly Report.';
+            const checklyStatus = checklyFailed ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced' : ':white_check_mark: All Playwright tests passed. Checkly Report';
 
             const existingComment = await github.rest.issues.listComments({
               issue_number: context.issue.number,

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -154,4 +154,3 @@ jobs:
               repo: context.repo.repo,
               body: `<details><summary>${checklyStatus}:</summary>\n\n${report}</details>`
             });
-

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -117,9 +117,16 @@ jobs:
       - name: Run checks # Run Checkly checks and record test session
         id: run-checks
         if: github.ref != 'refs/heads/main' # We don't want to run checks on main branch pushes
+        continue-on-error: true
         run: |
           npx checkly test --config=$(find . -name checkly.config.ts) -e ENVIRONMENT_URL=https://${{ env.FEATURE_BRANCH_NAME }}.${{ inputs.QA_SITE_DOMAIN }} --reporter=github --record
           cat checkly-github-report.md > $GITHUB_STEP_SUMMARY
+          # Check if the step failed
+          if [ $? -ne 0 ]; then
+            echo "::error::Checkly checks failed. Please check the checkly-github-report.md in the summary for more details."
+          else
+            echo "Checkly checks Passed! Please check the checkly-github-report.md in the summary for more details."
+          fi
       - name: Deploy checks # Deploy checks to Checkly for debugging
         # Only run if the pull request is merging into the main branch
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -147,7 +147,7 @@ jobs:
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
             const checklyFailed = '${{ steps.checkly-deploy.outputs.checkly_failed }}';
-            const checklyStatus = checklyFailed ? '(checklyFailed: ${checklyFailed}) :x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced' : '(checklyFailed: ${checklyFailed}) :white_check_mark: All Playwright tests passed. Checkly Report';
+            const checklyStatus = checklyFailed ? `:x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced (checklyFailed: ${checklyFailed})` : `:white_check_mark: All Playwright tests passed. Checkly Report (checklyFailed: ${checklyFailed})`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -141,7 +141,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm install @actions/github
           const fs = require('fs');
           const report = fs.readFileSync('checkly-github-report.md', 'utf8');
           const checklyFailed = ${{ steps.run-checks.outputs.checkly_failed }};
@@ -159,7 +158,11 @@ jobs:
             (comment) => comment.body.includes('Checkly Report')
           );
 
-          if (!existingReport || existingReport.body !== `<details><summary>${checklyStatus}:</summary>\n\n${report}</details>`) {
+          const existingChecklyStatus = existingReport
+            ? existingReport.body.split(':')[0]
+            : null;
+
+          if (!existingReport || existingChecklyStatus !== checklyStatus) {
             const commentParams = {
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -174,4 +177,3 @@ jobs:
               await github.rest.issues.createComment(commentParams);
             }
           }
-

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -144,10 +144,11 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
+            const checklyStatus = ${{ steps.run-checks.conclusion == 'success' && '✅' || '❌' }};
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `<details><summary>Checkly Report:</summary>\n\n${report}</details>`
+              body: `<details><summary>${checklyStatus} Checkly Report:</summary>\n\n${report}</details>`
             });
 

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -121,16 +121,16 @@ jobs:
         if: github.ref != 'refs/heads/main' # We don't want to run checks on main branch pushes
         # continue-on-error: true
         run: |
-          checkly_failed=false
           set +e # Disable exit on error
           npx checkly test --config=$(find . -name checkly.config.ts) -e ENVIRONMENT_URL=https://${{ env.FEATURE_BRANCH_NAME }}.${{ inputs.QA_SITE_DOMAIN }} --reporter=github --record
           exit_code=$?
           set -e # Enable exit on error
           if [ $exit_code -ne 0 ]; then
             echo "::error::Checkly checks failed. Please check the checkly-github-report.md in the summary for more details."
-            checkly_failed=true
+            echo "::set-output name=checkly_failed::true"
           else
             echo "::notice::Checkly checks Passed! Please check the checkly-github-report.md in the summary for more details."
+            echo "::set-output name=checkly_failed::false"
           fi
           cat checkly-github-report.md > $GITHUB_STEP_SUMMARY
       - name: Deploy checks # Deploy checks to Checkly for debugging
@@ -147,7 +147,7 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyStatus = $checkly_failed ? ':x:' : ':white_check_mark:';
+            const checklyStatus = ${{ steps.run-checks.outputs.checkly_failed }} ? ':x:' : ':white_check_mark:';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -137,7 +137,7 @@ jobs:
         id: deploy-checks
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
       - name: Post Checkly Report
-        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+        if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -121,12 +121,14 @@ jobs:
         if: github.ref != 'refs/heads/main' # We don't want to run checks on main branch pushes
         # continue-on-error: true
         run: |
+          checkly_failed=false
           set +e # Disable exit on error
           npx checkly test --config=$(find . -name checkly.config.ts) -e ENVIRONMENT_URL=https://${{ env.FEATURE_BRANCH_NAME }}.${{ inputs.QA_SITE_DOMAIN }} --reporter=github --record
           exit_code=$?
           set -e # Enable exit on error
           if [ $exit_code -ne 0 ]; then
             echo "::error::Checkly checks failed. Please check the checkly-github-report.md in the summary for more details."
+            checkly_failed=true
           else
             echo "::notice::Checkly checks Passed! Please check the checkly-github-report.md in the summary for more details."
           fi
@@ -145,12 +147,11 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyConclusion = '${{ steps.run-checks.conclusion }}';
-            const checklyStatus = checklyConclusion === 'success' ? ':white_check_mark:' : ':x:';
+            const checklyStatus = $checkly_failed ? ':x:' : ':white_check_mark:';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `<details><summary>##${checklyStatus} Checkly Report:</summary>\n\n${report}</details>`
+              body: `<details><summary>${checklyStatus} Checkly Report:</summary>\n\n${report}</details>`
             });
 

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -126,10 +126,10 @@ jobs:
           set -e # Enable exit on error
           if [ $exit_code -ne 0 ]; then
             echo "::error::Checkly checks failed. Please check the checkly-github-report.md in the summary for more details."
-            echo "::set-output name=checkly_failed::true"
+            echo "checkly_failed=true" >> $GITHUB_OUTPUT
           else
             echo "::notice::Checkly checks Passed! Please check the checkly-github-report.md in the summary for more details."
-            echo "::set-output name=checkly_failed::false"
+            echo "checkly_failed=false" >> $GITHUB_OUTPUT
           fi
           cat checkly-github-report.md > $GITHUB_STEP_SUMMARY
       - name: Deploy checks # Deploy checks to Checkly for debugging
@@ -145,7 +145,7 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyStatus = ${{ steps.run-checks.outputs.checkly_failed }} ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced' : ':white_check_mark: All Playwright tests passed. Checkly Report';
+            const checklyStatus = $checkly_failed ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced' : ':white_check_mark: All Playwright tests passed. Checkly Report';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Run checks # Run Checkly checks and record test session
         id: run-checks
         if: github.ref != 'refs/heads/main' # We don't want to run checks on main branch pushes
-        continue-on-error: true
+        # continue-on-error: true
         run: |
           set +e # Disable exit on error
           npx checkly test --config=$(find . -name checkly.config.ts) -e ENVIRONMENT_URL=https://${{ env.FEATURE_BRANCH_NAME }}.${{ inputs.QA_SITE_DOMAIN }} --reporter=github --record

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -147,7 +147,7 @@ jobs:
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
             const checklyFailed = '${{ steps.checkly-deploy.outputs.checkly_failed }}';
-            const checklyStatus = checklyFailed ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced' : ':white_check_mark: All Playwright tests passed. Checkly Report';
+            const checklyStatus = checklyFailed ? '(checklyFailed: ${checklyFailed}) :x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced' : '(checklyFailed: ${checklyFailed}) :white_check_mark: All Playwright tests passed. Checkly Report';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -146,7 +146,8 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyStatus = $checkly_failed ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced' : ':white_check_mark: All Playwright tests passed. Checkly Report';
+            const checklyFailed = '${{ steps.checkly-deploy.outputs.checkly_failed }}';
+            const checklyStatus = checklyFailed ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced' : ':white_check_mark: All Playwright tests passed. Checkly Report';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -138,17 +138,18 @@ jobs:
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
       - name: Add Checkly report comment to PR
         uses: actions/github-script@v6
+        # if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
         if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyStatus = ${{ steps.run-checks.conclusion == 'success' && '✅' || '❌' }};
+            const checklyStatus = ${{ steps.run-checks.conclusion == 'success' && ':white_check_mark:' || ':x:' }};
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `<details><summary>${checklyStatus} Checkly Report:</summary>\n\n${report}</details>`
+              body: `<details><summary>##${checklyStatus} Checkly Report:</summary>\n\n${report}</details>`
             });
 

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -134,8 +134,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         id: deploy-checks
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
-      # Add a comment to the PR with the checkly report in it.
-      - name: Add Checkly report comment
+      - name: Add Checkly report comment # Add a comment to the PR with the checkly report in it.
         uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         with:

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -147,11 +147,11 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyStatus = ${{ steps.run-checks.outputs.checkly_failed }} ? ':x: Some tests failed' : ':white_check_mark: All tests passed';
+            const checklyStatus = ${{ steps.run-checks.outputs.checkly_failed }} ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced' : ':white_check_mark: All Playwright tests passed. Checkly Report';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `<details><summary>${checklyStatus}. Review the Checkly Report:</summary>\n\n${report}</details>`
+              body: `<details><summary>${checklyStatus}:</summary>\n\n${report}</details>`
             });
 

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -136,7 +136,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         id: deploy-checks
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
-      - name: Add Checkly report comment # Add a comment to the PR with the checkly report in it.
+      - name: Add Checkly report comment to PR
         uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         with:
@@ -148,6 +148,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `Checkly Report:\n\n${report}`
+              body: `<details><summary>Checkly Report:</summary>\n\n${report}</details>`
             });
 

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -146,7 +146,7 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyFailed = '${{ steps.checkly-deploy.outputs.checkly_failed }}';
+            const checklyFailed = ${{ steps.checkly-deploy.outputs.checkly_failed }};
             const checklyStatus = checklyFailed ? `:x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced (checklyFailed: ${checklyFailed})` : `:white_check_mark: All Playwright tests passed. Checkly Report (checklyFailed: ${checklyFailed})`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -94,8 +94,6 @@ jobs:
     # if the check_files step in the check-qat job doesn't fail
     needs:
       - check-qat
-    # Run QAT only if the check-qat job succeeded, the event is a pull request, and the action is opened or ready_for_review
-    if: needs.check-qat.outputs.status == 'true' && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.pull_request.draft == true)
 
     concurrency:
       group: ${{ github.ref_name || github.run_id }}-checkly-qat
@@ -138,19 +136,42 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         id: deploy-checks
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
-      - name: Add Checkly report comment to PR
-        uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.pull_request.draft == true)
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyFailed = ${{ steps.run-checks.outputs.checkly_failed }};
-            const checklyStatus = checklyFailed ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced (checklyFailed: ${checklyFailed})' : ':white_check_mark: All Playwright tests passed. Checkly Report (checklyFailed: ${checklyFailed})';
-            github.rest.issues.createComment({
+      - name: Post Checkly Report
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm install @actions/github
+          const fs = require('fs');
+          const report = fs.readFileSync('checkly-github-report.md', 'utf8');
+          const checklyFailed = ${{ steps.run-checks.outputs.checkly_failed }};
+          const checklyStatus = checklyFailed ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced.' : ':white_check_mark: All Playwright tests passed. Checkly Report.';
+
+          const github = require('@actions/github');
+          const context = github.context;
+          const existingComments = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+
+          const existingReport = existingComments.data.find(
+            (comment) => comment.body.includes('Checkly Report')
+          );
+
+          if (!existingReport || existingReport.body !== `<details><summary>${checklyStatus}:</summary>\n\n${report}</details>`) {
+            const commentParams = {
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `<details><summary>${checklyStatus}:</summary>\n\n${report}</details>`
-            });
+              body: `<details><summary>${checklyStatus}:</summary>\n\n${report}</details>`,
+            };
+
+            if (existingReport) {
+              commentParams.comment_id = existingReport.id;
+              await github.rest.issues.updateComment(commentParams);
+            } else {
+              await github.rest.issues.createComment(commentParams);
+            }
+          }
+

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -145,8 +145,7 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyStatus = ${{ steps.run-checks.conclusion == 'success' && ':white_check_mark:' || ':x:' }};
-            github.rest.issues.createComment({
+            const checklyStatus = ${{ steps.run-checks.conclusion == 'success' ? ':white_check_mark:' : ':x:' }};            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -26,7 +26,8 @@ on:
 
 permissions:
   contents: read
-  issues: write
+  # To allow action to post to PR.
+  pull-requests: write
 
 # See https://www.checklyhq.com/docs/cli/command-line-reference/#npx-checkly-deploy and supporting documentation for
 # more details on Checkly environment variables.

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -134,3 +134,19 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         id: deploy-checks
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
+      # Add a comment to the PR with the checkly report in it.
+      - name: Add Checkly report comment
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('checkly-github-report.md', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Checkly Report:\n\n${report}`
+            });
+

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -145,7 +145,9 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyStatus = ${{ steps.run-checks.conclusion == 'success' ? ':white_check_mark:' : ':x:' }};            github.rest.issues.createComment({
+            const checklyConclusion = '${{ steps.run-checks.conclusion }}';
+            const checklyStatus = checklyConclusion === 'success' ? ':white_check_mark:' : ':x:';
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -139,7 +139,7 @@ jobs:
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
       - name: Add Checkly report comment to PR
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event.action == 'ready_for_review'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -147,11 +147,11 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-            const checklyStatus = ${{ steps.run-checks.outputs.checkly_failed }} ? ':x:' : ':white_check_mark:';
+            const checklyStatus = ${{ steps.run-checks.outputs.checkly_failed }} ? ':x: Some tests failed' : ':white_check_mark: All tests passed';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `<details><summary>${checklyStatus} Checkly Report:</summary>\n\n${report}</details>`
+              body: `<details><summary>${checklyStatus}. Review the Checkly Report:</summary>\n\n${report}</details>`
             });
 

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 # See https://www.checklyhq.com/docs/cli/command-line-reference/#npx-checkly-deploy and supporting documentation for
 # more details on Checkly environment variables.

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -94,7 +94,8 @@ jobs:
     # if the check_files step in the check-qat job doesn't fail
     needs:
       - check-qat
-    if: needs.check-qat.outputs.status == 'true'
+    # Run QAT only if the check-qat job succeeded, the event is a pull request, and the action is opened or ready_for_review
+    if: needs.check-qat.outputs.status == 'true' && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'ready_for_review')
 
     concurrency:
       group: ${{ github.ref_name || github.run_id }}-checkly-qat
@@ -139,7 +140,7 @@ jobs:
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
       - name: Add Checkly report comment to PR
         uses: actions/github-script@v6
-        if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event.action == 'ready_for_review'
+        if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'ready_for_review')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -138,7 +138,7 @@ jobs:
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
       - name: Add Checkly report comment to PR
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+        if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -136,44 +136,38 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         id: deploy-checks
         run: npx checkly deploy --config=$(find . -name checkly.config.ts) --force
-      - name: Post Checkly Report
-        if: github.event_name == 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          const fs = require('fs');
-          const report = fs.readFileSync('checkly-github-report.md', 'utf8');
-          const checklyFailed = ${{ steps.run-checks.outputs.checkly_failed }};
-          const checklyStatus = checklyFailed ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced.' : ':white_check_mark: All Playwright tests passed. Checkly Report.';
+      - name: Add Checkly report comment to PR
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('checkly-github-report.md', 'utf8');
+            const checklyFailed = ${{ steps.run-checks.outputs.checkly_failed }};
+            const checklyStatus = checklyFailed ? ':x: Some Playwright tests failed. Please review the Checkly Report to verify no breaking changes were introduced.' : ':white_check_mark: All Playwright tests passed. Checkly Report.';
 
-          const github = require('@actions/github');
-          const context = github.context;
-          const existingComments = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-          });
+            const existingComment = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
 
-          const existingReport = existingComments.data.find(
-            (comment) => comment.body.includes('Checkly Report')
-          );
+            // Delete any existing Checkly Report comments
+            for (const comment of existingComment.data) {
+              if (comment.body.includes('Checkly Report')) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id
+                });
+              }
+            };
 
-          const existingChecklyStatus = existingReport
-            ? existingReport.body.split(':')[0]
-            : null;
-
-          if (!existingReport || existingChecklyStatus !== checklyStatus) {
-            const commentParams = {
+            // Create a new Checkly Report comment
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '<details><summary>' + checklyStatus + ':</summary>\n\n' + report + '</details>',
-            };
-
-            if (existingReport) {
-              commentParams.comment_id = existingReport.id;
-              await github.rest.issues.updateComment(commentParams);
-            } else {
-              await github.rest.issues.createComment(commentParams);
-            }
-          }
+              body: `<details><summary>${checklyStatus}:</summary>\n\n${report}</details>`
+            });

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -120,13 +120,12 @@ jobs:
         continue-on-error: true
         run: |
           npx checkly test --config=$(find . -name checkly.config.ts) -e ENVIRONMENT_URL=https://${{ env.FEATURE_BRANCH_NAME }}.${{ inputs.QA_SITE_DOMAIN }} --reporter=github --record
-          cat checkly-github-report.md > $GITHUB_STEP_SUMMARY
-          # Check if the step failed
           if [ $? -ne 0 ]; then
             echo "::error::Checkly checks failed. Please check the checkly-github-report.md in the summary for more details."
           else
             echo "Checkly checks Passed! Please check the checkly-github-report.md in the summary for more details."
           fi
+          cat checkly-github-report.md > $GITHUB_STEP_SUMMARY
       - name: Deploy checks # Deploy checks to Checkly for debugging
         # Only run if the pull request is merging into the main branch
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -167,7 +167,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `<details><summary>${checklyStatus}:</summary>\n\n${report}</details>`,
+              body: '<details><summary>' + checklyStatus + ':</summary>\n\n' + report + '</details>',
             };
 
             if (existingReport) {

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -126,7 +126,7 @@ jobs:
           if [ $exit_code -ne 0 ]; then
             echo "::error::Checkly checks failed. Please check the checkly-github-report.md in the summary for more details."
           else
-            echo "Checkly checks Passed! Please check the checkly-github-report.md in the summary for more details."
+            echo "::notice::Checkly checks Passed! Please check the checkly-github-report.md in the summary for more details."
           fi
           cat checkly-github-report.md > $GITHUB_STEP_SUMMARY
       - name: Deploy checks # Deploy checks to Checkly for debugging


### PR DESCRIPTION
## Summary
This PR, when applied,
* Updates the QAT job to always pass as long as the Checkly report is able to run and deploy.
* Generates a PR comment with the Checkly report for better visibility.
* Deletes older Report comments for cleanliness.

## Issue URL or additional context
This update should reduce some confusion and false alarms for when a Checkly test fails. Originally the check would fail for reasons unrelated to the PR due to things like timeouts or external misconfiguration. This would result in a ❌ in the CI checks and, while not required, prevents the engineer from seeing that comforting ✅ and raising concerns. 

While we do want the engineer to still be aware and cautious if their changes introduce breaking changes validated by the Playwright tests, we don't want it creating too much friction in our workflow, especially with some of the false positives that Checkly test can encounter with timeouts.

## QA
Example PR with the new workflow temporarily enabled: https://github.com/penske-media-corp/pmc-variety-2020/pull/597

Example of what will show when all Playwright tests pass:

![Screenshot 2024-08-22 at 3 02 54 PM](https://github.com/user-attachments/assets/613a98eb-f311-4872-bf92-ed709f874963)
![Screenshot 2024-08-22 at 3 03 06 PM](https://github.com/user-attachments/assets/7e468d59-cb1f-4145-8033-f2902e2b9eb3)


When there are test failing, we now have a new indicator that doesn't add too much friction to the PR:

![Screenshot 2024-08-22 at 3 04 03 PM](https://github.com/user-attachments/assets/a6d251d2-f9cb-4e4a-83e9-7a1615ff426f)
![Screenshot 2024-08-22 at 3 04 09 PM](https://github.com/user-attachments/assets/7300b7ff-c959-493d-bd26-781e05870d17)

## TODO List
* [ ] Code is tested.
* [ ] Documentation has been updated.
* [ ] QA evidence is included.