### PR TITLE
Update Sonar action slug

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -204,7 +204,7 @@ jobs:
           fi
 
       - name: Analyze with SonarCloud
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           # Token needed to get PR information, if any.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`sonarcloud-github-action` is dead. Long live `sonarcloud-github-action`.

From the README:

> [!WARNING]
> This action is deprecated and will be removed in a future release. 
> Please use the `sonarqube-scan-action` action instead. 
> The `sonarqube-scan-action` is a drop-in replacement for this action.