### PR TITLE
PMCP-7054: Add WP 6.7 unit testing (non-failing) to workflow.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -73,6 +73,14 @@ jobs:
             job_label_php: 'current'
             job_label_wordpress: 'latest'
 
+            # Temporary WordPress 6.7 testing (PMCP-7054)
+          - php: '8.2'
+            wordpress: '6.7'
+            check_code_coverage: false
+            continue_on_error: true # non-failing
+            job_label_php: 'current'
+            job_label_wordpress: '6.7'
+
     steps:
       - name: Prepare environment
         uses: penske-media-corp/github-action-wordpress-test-setup@main


### PR DESCRIPTION
To test the upgrade of WordPress to version 6.7, we will need to run unit tests against that version. 

This adds a non-failing check to the workflow.
