### PR TITLE
QAT - Fixes

### DIFF
--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -57,8 +57,9 @@ jobs:
             HASH_URL="https://${BRANCH_NAME}.${{ inputs.QA_SITE_DOMAIN }}/wp-content-vipgo-sites/${BRANCH_NAME}/themes/vip/${{ inputs.THEME_NAME }}/version-hash"
           fi
 
-          echo "ENVIRONMENT_URL=$ENVIRONMENT_URL" >> $GITHUB_ENV
-          echo "HASH_URL=$HASH_URL" >> $GITHUB_ENV      
+          # Convert URLs to lowercase and export to environment
+          echo "ENVIRONMENT_URL=$(echo $ENVIRONMENT_URL | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "HASH_URL=$(echo $HASH_URL | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV      
 
       - name: Quality Assurance Testing (QAT)
         id: qat


### PR DESCRIPTION
## Changes
- [x] Lowercase `ENVIRONMENT_URL` and `HASH_URL`
  - The following hash url fails because `https://TG-270.wwd.pmcqa.com/wp-content-vipgo-sites/TG-270/themes/vip/pmc-wwd-2021/version-hash` gets translated by the browser to `https://tg-270.wwd.pmcqa.com/wp-content-vipgo-sites/TG-270/themes/vip/pmc-wwd-2021/version-hash` (notice the branch in the middle of the URL is still uppercase)