### PR TITLE
Revert "QAT - Support older usages"

### DIFF
--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -19,16 +19,6 @@ on:
         required: false
       CHECKLY_ACCOUNT_ID:
         required: false
-        
-      # these two secrets are added just to support older
-      # themes which have no QAT, but define an older
-      # version of the QAT job, e.g.
-      # https://github.com/penske-media-corp/pmc-soaps-2018/blob/c555da8b7174d5691bf0b66b8a35f0260dc5128a/.github/workflows/pmc.yaml#L67-L72
-      # once those are removed the below secrets may also be removed.
-      BITBUCKET_READ_ONLY_SSH_KEY:
-        required: false
-      GITHUB_READ_ONLY_SSH_KEY:
-        required: false
 
 jobs:
   qat:


### PR DESCRIPTION
Reverts penske-media-corp/github-workflows-wordpress#55 

This change is no longer needed now that the old `qat` job has been removed from our organization. See the following PRs

https://github.com/penske-media-corp/pmc-wwd-studios-2017/pull/6
https://github.com/penske-media-corp/pmc-corporate-2018/pull/17
https://github.com/penske-media-corp/pmc-sheknows-2020/pull/138
https://github.com/penske-media-corp/pmc-deadline-2019/pull/217
https://github.com/penske-media-corp/pmc-goldderby/pull/379
https://github.com/penske-media-corp/pmc-spy-2022/pull/120
https://github.com/penske-media-corp/pmc-vibe-2021/pull/140
https://github.com/penske-media-corp/pmc-artnews-2019/pull/250
https://github.com/penske-media-corp/pmc-dirt-2020/pull/34
https://github.com/penske-media-corp/pmc-blogher-2020/pull/40
https://github.com/penske-media-corp/pmc-footwearnews-2018/pull/101
https://github.com/penske-media-corp/pmc-salesmicrosite/pull/11
https://github.com/penske-media-corp/pmc-engineering-2021/pull/14
https://github.com/penske-media-corp/pmc-core-v2/pull/52
https://github.com/penske-media-corp/pmc-hollywoodreporter-2021/pull/279
https://github.com/penske-media-corp/pmc-summits/pull/18
https://github.com/penske-media-corp/pmc-soaps-2018/pull/85