### PR TITLE
Remove old QAT example

### DIFF
--- a/templates/pmc.yml
+++ b/templates/pmc.yml
@@ -36,13 +36,6 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
 
-  qat:
-    name: QAT
-    uses: penske-media-corp/github-workflows-wordpress/.github/workflows/qat.yml@main
-    secrets:
-      BITBUCKET_READ_ONLY_SSH_KEY: ${{ secrets.BITBUCKET_READ_ONLY_SSH_KEY }}
-      GITHUB_READ_ONLY_SSH_KEY: ${{ secrets.PMC_GITHUB_ACTION_SSH_KEY }}
-
   unit-tests:
     name: Unit Tests
     uses: penske-media-corp/github-workflows-wordpress/.github/workflows/unit-tests.yml@main


### PR DESCRIPTION
This template is no longer accurate. See related PRs

https://github.com/penske-media-corp/pmc-wwd-studios-2017/pull/6
https://github.com/penske-media-corp/pmc-corporate-2018/pull/17
https://github.com/penske-media-corp/pmc-sheknows-2020/pull/138
https://github.com/penske-media-corp/pmc-deadline-2019/pull/217
https://github.com/penske-media-corp/pmc-goldderby/pull/379
https://github.com/penske-media-corp/pmc-spy-2022/pull/120
https://github.com/penske-media-corp/pmc-vibe-2021/pull/140
https://github.com/penske-media-corp/pmc-artnews-2019/pull/250
https://github.com/penske-media-corp/pmc-dirt-2020/pull/34
https://github.com/penske-media-corp/pmc-blogher-2020/pull/40
https://github.com/penske-media-corp/pmc-footwearnews-2018/pull/101
https://github.com/penske-media-corp/pmc-salesmicrosite/pull/11
https://github.com/penske-media-corp/pmc-engineering-2021/pull/14
https://github.com/penske-media-corp/pmc-core-v2/pull/52
https://github.com/penske-media-corp/pmc-hollywoodreporter-2021/pull/279
https://github.com/penske-media-corp/pmc-summits/pull/18
https://github.com/penske-media-corp/pmc-soaps-2018/pull/85

If QAT is needed in a project, there are examples like this one https://github.com/penske-media-corp/pmc-sourcingjournal-2021/blob/main/.github/workflows/pmc.yaml#L101-L109