### PR TITLE
QAT - Fix naming and permissions

### DIFF
--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Quality Assurance Testing (QAT)
         id: qat
-        uses: penske-media-corp/pmc-github-actions/actions/tests/checkly@main
+        uses: penske-media-corp/pmc-github-actions/actions/tests/checkly@feature/qat
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -22,7 +22,10 @@ on:
 
 jobs:
   qat:
-    name: QAT
+    name: Playwright Tests
+    permissions:
+      contents: read
+      pull-requests: write  # Required to comment on PRs
     runs-on: ubuntu-latest
     timeout-minutes: 90
     if: ${{ github.repository != 'penske-media-corp/github-workflows-wordpress' }}

--- a/.github/workflows/qat.yml
+++ b/.github/workflows/qat.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Quality Assurance Testing (QAT)
         id: qat
-        uses: penske-media-corp/pmc-github-actions/actions/tests/checkly@feature/qat
+        uses: penske-media-corp/pmc-github-actions/actions/tests/checkly@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Depends upon https://github.com/penske-media-corp/pmc-github-actions/pull/33

## Changes
- [x] Move write permission definition from the composite action to the caller (this repo's qat action) as composite actions should not contain permission definitions.
- [x] Tweak job name from `QAT` to `Playwright Tests`.