### PR TITLE
Retrieve 1000 lines from Vercel build logs

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -69,4 +69,4 @@ jobs:
         run: |
           VERCEL_CMD="npx vercel@32.1.0 --no-color --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_ORG_ID }}"
           DEPLOY_URL=$($VERCEL_CMD ls ${{ inputs.VERCEL_PROJECT_NAME }} --meta githubCommitSha=${{ github.sha }} | grep -Eo "https://${{ inputs.VERCEL_PROJECT_NAME }}-([^-]+)-${{ inputs.VERCEL_ORG_SlUG }}.vercel.app" )
-          $VERCEL_CMD logs --output raw $DEPLOY_URL
+          $VERCEL_CMD logs --output raw --limit 1000 $DEPLOY_URL


### PR DESCRIPTION
On failure, increase lines returned from default of `100` to `1000`.