### PR TITLE
PUB-489 - Use stable job labels for unit test and linting workflows

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -34,7 +34,9 @@ jobs:
         include:
           - php: ${{ inputs.PHP_VERSION }}
             continue_on_error: false
-            job_label: ${{ inputs.PHP_VERSION }}
+            # Use stable label so dependent repos can rely on a fixed required check name
+            # in GitHub branch protection (e.g. "Linting / PHP: current").
+            job_label: current
 
     steps:
       - name: Prepare environment

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -86,8 +86,10 @@ jobs:
             jetpack: ${{ inputs.JETPACK_VERSION }}
             check_code_coverage: true
             continue_on_error: false
-            job_label_php: ${{ inputs.PHP_VERSION }}
-            job_label_wordpress: ${{ inputs.WORDPRESS_VERSION }}
+            # Use stable labels so dependent repos can rely on fixed required check names
+            # in GitHub branch protection (e.g. "Unit Tests / PHP: current, WP: latest").
+            job_label_php: current
+            job_label_wordpress: latest
 
     steps:
       - name: Prepare environment


### PR DESCRIPTION
Hardcode matrix job labels to `current` and `latest` instead of deriving them from version inputs. This prevents GitHub branch protection required checks from breaking every time default PHP or WordPress versions are bumped.

## Changes

- **unit-tests.yml**: Set `job_label_php` to `current` and `job_label_wordpress` to `latest` so the check name is always `Unit Tests / PHP: current, WP: latest`
- **linting.yml**: Set `job_label` to `current` so the check name is always `Linting / PHP: current`
- Actual PHP and WordPress versions used for testing are unchanged — only display labels are affected

<img width="836" height="146" alt="Screenshot 2026-04-09 at 11 46 02 AM" src="https://github.com/user-attachments/assets/d638dc8c-5300-4f15-aaf6-4e50fe2c9320" />



## JIRA Ticket

https://penskemedia.atlassian.net/browse/PUB-489